### PR TITLE
FEAT: 그룹조회 유저와 맴버나눠서 전달

### DIFF
--- a/src/main/java/com/woory/backend/controller/GroupController.java
+++ b/src/main/java/com/woory/backend/controller/GroupController.java
@@ -1,5 +1,6 @@
 package com.woory.backend.controller;
 
+import com.woory.backend.dto.DataDto;
 import com.woory.backend.dto.GroupDto;
 import com.woory.backend.dto.GroupInfoDto;
 import com.woory.backend.entity.Group;
@@ -48,7 +49,7 @@ public class GroupController {
     // 그룹 조회
     @GetMapping("/get/{groupId}")
     public ResponseEntity<Map<String, Object>> getMyGroup(@PathVariable("groupId") Long groupId) {
-        List<GroupInfoDto> groups = groupService.getMyGroupId(groupId);
+        DataDto groups = groupService.getMyGroupId(groupId);
         Map<String, Object> response = StatusUtil.getStatusMessage("가족 정보 조회 성공했습니다");
         response.put("data", groups);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/woory/backend/dto/DataDto.java
+++ b/src/main/java/com/woory/backend/dto/DataDto.java
@@ -1,0 +1,17 @@
+package com.woory.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class DataDto {
+    private UserDetailDto user;
+    private List<MemberDetailDto> members;
+}

--- a/src/main/java/com/woory/backend/dto/MemberDetailDto.java
+++ b/src/main/java/com/woory/backend/dto/MemberDetailDto.java
@@ -1,0 +1,14 @@
+package com.woory.backend.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class MemberDetailDto {
+    private Long userId;
+    private String userName;
+    private String profileUrl;
+    private boolean isHouseholder;
+}

--- a/src/main/java/com/woory/backend/dto/UserDetailDto.java
+++ b/src/main/java/com/woory/backend/dto/UserDetailDto.java
@@ -1,0 +1,15 @@
+package com.woory.backend.dto;
+
+import lombok.*;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class UserDetailDto {
+    private Long userId;
+    private String userName;
+    private String profileUrl;
+    private boolean isHouseholder;
+}

--- a/src/main/java/com/woory/backend/repository/GroupUserRepository.java
+++ b/src/main/java/com/woory/backend/repository/GroupUserRepository.java
@@ -40,4 +40,9 @@ public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
 	void deleteByGroup_GroupId(Long groupId);
 
 	boolean existsByGroup_GroupId(Long groupId);
+
+	@Query("select gu from GroupUser gu where gu.group.groupId = :groupId and gu.user.userId != :userId ")
+	List<GroupUser> findGroupUserWithoutUser(@Param("groupId") Long groupId, @Param("userId") Long userId);
+
+
 }

--- a/src/main/java/com/woory/backend/repository/UserRepository.java
+++ b/src/main/java/com/woory/backend/repository/UserRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByUsername(String username);
-
+	Optional<User> findByUserId(Long userId);
 	@Query("select u from User u left join fetch u.groupUsers gu where u.userId = :userId and (gu is null or gu.status != com.woory.backend.entity.GroupStatus.BANNED)")
 	Optional<User> findByUserIdWithGroups(@Param("userId") long id);
 }


### PR DESCRIPTION
dto생성 유저와 유저를제외한 그룹유저 레포지토리 생성

## PULL REQUEST

### 관련 이슈

> FEAT: 그룹조회 유저와 맴버나눠서 전달

### 작업중인 브랜치

> feat/left

### 작업 내용

> DTO생성 repository에 유저 불러오는 쿼리생성,유저제외한나머지맴버가져오기

**주요 변경사항**

---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
