### PR TITLE
기능 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/woory/backend/controller/ContentController.java
+++ b/src/main/java/com/woory/backend/controller/ContentController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +110,7 @@ public class ContentController {
 			throw new CustomException(ErrorCode.INVALID_DATE_FORMAT);
 		}
 
-		if(parse.isAfter(LocalDate.now())){
+		if(parse.isAfter(LocalDateTime.now().plusHours(9L).toLocalDate())){
 			throw new CustomException(ErrorCode.CAN_NOT_VIEW_AFTER_TODAY);
 		}
 

--- a/src/main/java/com/woory/backend/controller/ContentController.java
+++ b/src/main/java/com/woory/backend/controller/ContentController.java
@@ -88,7 +88,7 @@ public class ContentController {
 
 	 @Operation(summary = "단독 content 조회")
 	 @GetMapping("/get/{contentId}")
-	 public ResponseEntity<Map<String, Object>> getContents(@PathVariable Long contentId) {
+	 public ResponseEntity<Map<String, Object>> getContents(@PathVariable("contentId") Long contentId) {
 		 ContentWithUserDto content = contentService.getContent(contentId);
 	 	Map<String, Object> response = StatusUtil.getStatusMessage("컨텐츠가 조회되었습니다");
 	 	response.put("content", content);

--- a/src/main/java/com/woory/backend/dto/ContentWithUserDto.java
+++ b/src/main/java/com/woory/backend/dto/ContentWithUserDto.java
@@ -29,8 +29,8 @@ public class ContentWithUserDto {
 	private String contentImgPath;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private Date contentRegDate;
-	private int commentsCount;
-	private int reactionCount;
+	private Integer commentsCount;
+	private Integer reactionCount;
 
 	public static ContentWithUserDto toContentWithUserDto(Long userId, Content content) {
 		User user = content.getUsers();
@@ -50,6 +50,23 @@ public class ContentWithUserDto {
 			.IsEdit(userId.equals(contentUserId))
 			.commentsCount(commentsCount)
 			.reactionCount(size)
+			.build();
+	}
+
+	public static ContentWithUserDto toContentWithUserDtoWithoutCounts(Long userId, Content content) {
+		User user = content.getUsers();
+		Long contentUserId = user.getUserId();
+		String nickname = user.getNickname();
+		String profileImage = user.getProfileImage();
+		return ContentWithUserDto.builder()
+			.userId(contentUserId)
+			.name(nickname)
+			.profileUrl(profileImage)
+			.contentId(content.getContentId())
+			.contentImgPath(content.getContentImgPath())
+			.contentText(content.getContentText())
+			.contentRegDate(content.getContentRegDate())
+			.IsEdit(userId.equals(contentUserId))
 			.build();
 	}
 

--- a/src/main/java/com/woory/backend/entity/Comment.java
+++ b/src/main/java/com/woory/backend/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.woory.backend.entity;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.woory.backend.dto.CommentRequestDto;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -53,5 +54,15 @@ public class Comment {
 	public void removeReply(Comment reply) {
 		replies.remove(reply);
 		reply.setParentComment(null);
+	}
+
+	public static Comment toComment(CommentRequestDto requestDto, Comment parentComment, Content content, User user) {
+		return Comment.builder()
+			.commentText(requestDto.getCommentText())
+			.content(content)
+			.parentComment(parentComment)
+			.users(user)
+			.commentDate(new Date())
+			.build();
 	}
 }

--- a/src/main/java/com/woory/backend/entity/GroupStatus.java
+++ b/src/main/java/com/woory/backend/entity/GroupStatus.java
@@ -1,9 +1,7 @@
 package com.woory.backend.entity;
 
 public enum GroupStatus {
-	NON_MEMBER(0),
 	MEMBER(1),
-	BANNED(2),
 	GROUP_LEADER(3);
 
 	private final int value;

--- a/src/main/java/com/woory/backend/error/ErrorCode.java
+++ b/src/main/java/com/woory/backend/error/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
 	GROUP_CREATION_LIMIT_EXCEEDED(400, "GROUP_001", "사용자는 5개 이상의 가족그룹을 가질수 없습니다."),
 	NO_PERMISSION_TO_DELETE_GROUP(403, "GROUP_002", "가족을 삭제할 권한을 가지고 있지 않습니다."),
+	NO_PERMISSION_TO_KICK_MEMBER(403, "GROUP_003", "가족을 추방할 권한이 없습니다."),
 	USER_ALREADY_MEMBER(400, "GROUP_003", "사용자는 이미 가족에 포함되어있습니다."),
 	NO_PERMISSION_TO_UPDATE_GROUP(400, "GROUP_004", "가족을 수정할 권한이 없습니다."),
 	// UserService,

--- a/src/main/java/com/woory/backend/repository/BatchTopicRepositoryImpl.java
+++ b/src/main/java/com/woory/backend/repository/BatchTopicRepositoryImpl.java
@@ -28,7 +28,7 @@ public class BatchTopicRepositoryImpl implements BatchTopicRepository{
 	public int[] saveAll(List<TopicDto> topics) {
 		log.info("토픽 배치 저장 실행");
 		return jdbcTemplate.batchUpdate(
-			"INSERT INTO TOPIC(topic_content, issue_date, group_id, topic_byte) VALUES(:topicContent, :issueDate, :groupId, :topicByte)",
+			"INSERT INTO topic(topic_content, issue_date, group_id, topic_byte) VALUES(:topicContent, :issueDate, :groupId, :topicByte)",
 			SqlParameterSourceUtils.createBatch(topics)
 		);
 	}

--- a/src/main/java/com/woory/backend/repository/GroupUserRepository.java
+++ b/src/main/java/com/woory/backend/repository/GroupUserRepository.java
@@ -15,19 +15,19 @@ import java.util.Optional;
 
 @Repository
 public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
-	@Modifying
+	@Modifying(clearAutomatically = true)
 	@Query("UPDATE GroupUser gu SET gu.status = :newStatus WHERE gu.group.groupId = :groupId AND gu.user.userId = :userId")
 	void updateStatusByGroup_GroupIdAndUser_UserId(@Param("groupId") Long groupId, @Param("userId") Long userId,
 		@Param("newStatus") GroupStatus newStatus);
 
-	@Query("select gu from GroupUser gu where gu.group.groupId = :groupId and gu.status != com.woory.backend.entity.GroupStatus.BANNED order by gu.regDate asc")
-	List<GroupUser> findActiveGroupUsersByGroupIdOrderByRegDate(@Param("groupId") Long groupId);
+	@Query("select gu from GroupUser gu where gu.group.groupId = :groupId order by gu.regDate asc")
+	List<GroupUser> findGroupUsersByGroupIdOrderByRegDate(@Param("groupId") Long groupId);
 
 	// 그룹 유저에서 유저 아이디로 검색 후 그룹까지 조회
-	@Query("select new com.woory.backend.dto.GroupInfoDto(g.groupId, g.groupName, g.photoPath, gu.status) from GroupUser gu join gu.group g on g = gu.group where gu.status != com.woory.backend.entity.GroupStatus.BANNED and gu.user.userId = :userId order by gu.regDate asc")
+	@Query("select new com.woory.backend.dto.GroupInfoDto(g.groupId, g.groupName, g.photoPath, gu.status) from GroupUser gu join gu.group g on g = gu.group and gu.user.userId = :userId order by gu.regDate asc")
 	List<GroupInfoDto> findMyGroupInfoDto(@Param("userId") Long userId);
 
-	@Query("select new com.woory.backend.dto.GroupInfoDto(g.groupId, g.groupName, g.photoPath, gu.status) from GroupUser gu join gu.group g on g = gu.group where gu.status != com.woory.backend.entity.GroupStatus.BANNED and gu.group.groupId = :groupId order by gu.regDate asc")
+	@Query("select new com.woory.backend.dto.GroupInfoDto(g.groupId, g.groupName, g.photoPath, gu.status) from GroupUser gu join gu.group g on g = gu.group and gu.group.groupId = :groupId order by gu.regDate asc")
 	List<GroupInfoDto> findMyGroupInfoDtoByGrooupId(@Param("groupId") Long groupId);
 
 	Optional<GroupUser> findByUser_UserIdAndGroup_GroupId(Long userId, Long groupId);
@@ -42,7 +42,7 @@ public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
 
 	boolean existsByGroup_GroupId(Long groupId);
 
-	@Query("select gu from GroupUser gu where gu.group.groupId = :groupId and gu.user.userId != :userId and gu.status != com.woory.backend.entity.GroupStatus.BANNED")
+	@Query("select gu from GroupUser gu where gu.group.groupId = :groupId and gu.user.userId != :userId")
 	List<GroupUser> findGroupUserWithoutUser(@Param("groupId") Long groupId, @Param("userId") Long userId);
 
 	@Query("select gu from GroupUser gu join fetch gu.user u where u.userId = :userId and gu.group.groupId = :groupId")

--- a/src/main/java/com/woory/backend/repository/UserRepository.java
+++ b/src/main/java/com/woory/backend/repository/UserRepository.java
@@ -13,6 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByUsername(String username);
 	Optional<User> findByUserId(Long userId);
-	@Query("select u from User u left join fetch u.groupUsers gu where u.userId = :userId and (gu is null or gu.status != com.woory.backend.entity.GroupStatus.BANNED)")
+	@Query("select u from User u left join fetch u.groupUsers gu where u.userId = :userId")
 	Optional<User> findByUserIdWithGroups(@Param("userId") long id);
 }

--- a/src/main/java/com/woory/backend/service/ContentService.java
+++ b/src/main/java/com/woory/backend/service/ContentService.java
@@ -92,8 +92,9 @@ public class ContentService {
 	@Transactional
 	public void deleteContent(Long groupId, Long contentId) {
 		Long userId = SecurityUtil.getCurrentUserId();
-		GroupStatus status = groupUserRepository.findByUser_UserIdAndGroup_GroupId(userId, groupId)
-			.orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND)).getStatus();
+		groupUserRepository.findByUser_UserIdAndGroup_GroupId(userId, groupId)
+			.orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
+
 		Content content = contentRepository.findById(contentId)
 			.orElseThrow(() -> new CustomException(ErrorCode.CONTENT_NOT_FOUND));
 
@@ -101,9 +102,7 @@ public class ContentService {
 		if (!content.getUsers().getUserId().equals(userId)) {
 			throw new CustomException(ErrorCode.NO_PERMISSION_TO_DELETE);
 		}
-		if (status == GroupStatus.BANNED || status == GroupStatus.NON_MEMBER) {
-			throw new CustomException(ErrorCode.NO_PERMISSION_TO_DELETE);
-		}
+
 		contentRepository.delete(content);
 	}
 
@@ -113,17 +112,14 @@ public class ContentService {
 
 		groupUserRepository.findByUser_UserIdAndGroup_GroupId(userId, groupId)
 			.orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
+
 		Content content = contentRepository.findById(contentId)
 			.orElseThrow(() -> new CustomException(ErrorCode.CONTENT_NOT_FOUND));
-		GroupStatus status = getGroupStatus(userId, groupId);
 
 		if (!content.getUsers().getUserId().equals(userId)) {
 			throw new CustomException(ErrorCode.NO_PERMISSION_TO_UPDATE);
 		}
 
-		if (status == GroupStatus.BANNED || status == GroupStatus.NON_MEMBER) {
-			throw new CustomException(ErrorCode.NO_PERMISSION_TO_UPDATE);
-		}
 		content.setContentText(contentText);
 		if (contentImg != null) {
 			content.setContentImgPath(contentImg); // 사진 경로 수정
@@ -186,7 +182,7 @@ public class ContentService {
 			.orElseThrow(() -> new CustomException(ErrorCode.CONTENT_NOT_FOUND));
 		Long groupId = content.getTopic().getGroup().getGroupId();
 		checkUserGroup(groupId, currentUserId);
-		return ContentWithUserDto.toContentWithUserDto(currentUserId, content);
+		return ContentWithUserDto.toContentWithUserDtoWithoutCounts(currentUserId, content);
 
 	}
 
@@ -309,7 +305,7 @@ public class ContentService {
 
 	private void checkUserGroup(Long groupId, Long currentUserId) {
 		groupUserRepository.findByUser_UserIdAndGroup_GroupId(currentUserId, groupId)
-				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 	}
 
 	public TopicDto getTopicOnly(LocalDate date, Long groupId) {

--- a/src/test/java/com/woory/backend/repository/GroupRepositoryTest.java
+++ b/src/test/java/com/woory/backend/repository/GroupRepositoryTest.java
@@ -82,28 +82,4 @@ public class GroupRepositoryTest {
 		assertEquals(myGroup.get(0).getGroupName(), "우리1");
 
 	}
-
-	@Test
-	void 밴된_그룹_DTO로_조회() {
-		Group group = new Group();
-		group.setGroupName("우리1");
-		User user = new User();
-		user.setNickname("이름1");
-
-		User save = userRepository.save(user);
-		GroupUser groupUser = new GroupUser();
-		groupUser.setUser(user);
-		groupUser.setGroup(group);
-		groupUser.setStatus(GroupStatus.BANNED);
-		group.setGroupUsers(List.of(groupUser));
-		groupRepository.save(group);
-		// given
-		long userId = save.getUserId();
-
-		// when
-		List<GroupInfoDto> myGroup = groupUserRepository.findMyGroupInfoDto(userId);
-
-		// then
-		assertEquals(myGroup.size(), 0);
-	}
 }


### PR DESCRIPTION
## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**
- 컨텐츠 조회 시 KST 기준으로 받아오고 조회 전 UTC 기준으로 판단하여 두 규격이 맞지 않는 문제를 수정함
- 데이터베이스에 저장된 테이블명과 쿼리에 작성된 테이블명이 달라 배치 저장이 되지 않았던 문제 수정
- 기존 추방 이후 다시는 가족에 들어올 수 없었던 문제를 추방 이후에도 참여 가능하도록 수정
- 그 과정에서 GroupStatus.BANNED를 사용하지 않도록 수정하였고 해당 속성을 사용하던 쿼리문과 ContentService 코드에서 삭제함
- GroupStatus.BANNED를 사용하지 않게 되면서 이를 사용하던 모든 코드 수정
- GroupWithUserDto를 공유하던 과정에서 count 변수들 기본값이 0이 원하지 않는 경우에도 들어가는 문제가 있어 래퍼 클래스로 타입 수정
- PathVariable 필드 값을 못 읽어오던 부분 수정
---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
