### PR TITLE
마음함 조회 기능 추가

### DIFF
--- a/src/main/java/com/woory/backend/controller/ContentController.java
+++ b/src/main/java/com/woory/backend/controller/ContentController.java
@@ -170,4 +170,19 @@ public class ContentController {
 
 		return ResponseEntity.ok(statusMessage);
 	}
+
+	@PostMapping("/{groupId}/favorites/{topicId}")
+	public Map<String, Object> pushFavorite(@PathVariable("groupId") Long groupId,
+		@PathVariable("topicId") Long topicId) {
+		contentService.addOrDeleteHeart(groupId, topicId);
+		return StatusUtil.getStatusMessage("마음 추가/삭제에 성공했습니다.");
+	}
+
+	@GetMapping("{groupId}/favorites")
+	public Map<String, Object> getFavoritesInThisGroup(@PathVariable("groupId") Long groupId) {
+		List<FavoriteDto> favorites = contentService.getFavorites(groupId);
+		Map<String, Object> response = StatusUtil.getStatusMessage("마음함 조회에 성공했습니다.");
+		response.put("data", favorites);
+		return response;
+	}
 }

--- a/src/main/java/com/woory/backend/dto/FavoriteDto.java
+++ b/src/main/java/com/woory/backend/dto/FavoriteDto.java
@@ -1,0 +1,25 @@
+package com.woory.backend.dto;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FavoriteDto {
+	private Long topicId;
+	private Date issueDate;
+	private String contentImg;
+	private String topicText;
+
+	public FavoriteDto(Long topicId, Date issueDate, String contentImg, String topicText) {
+		this.topicId = topicId;
+		this.issueDate = issueDate;
+		this.contentImg = contentImg;
+		this.topicText = topicText;
+	}
+}

--- a/src/main/java/com/woory/backend/entity/Topic.java
+++ b/src/main/java/com/woory/backend/entity/Topic.java
@@ -36,6 +36,7 @@ public class Topic {
 
 	@Builder.Default
 	@OneToMany(mappedBy = "topic", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	@OrderBy("contentRegDate asc")
 	private List<Content> content = new ArrayList<>();
 
 	public static Topic fromTopicSetWithDateAndGroup(Group group, TopicSet topicSet, Date date) {

--- a/src/main/java/com/woory/backend/repository/FavoriteRepository.java
+++ b/src/main/java/com/woory/backend/repository/FavoriteRepository.java
@@ -1,0 +1,23 @@
+package com.woory.backend.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.woory.backend.entity.Favorite;
+import com.woory.backend.entity.GroupUser;
+import com.woory.backend.entity.Topic;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+	boolean existsByTopicAndGroupUser(Topic topic, GroupUser groupUser);
+
+	@Modifying
+	@Query("delete from Favorite f where f.groupUser = :groupUser and f.topic = :topic")
+	void deleteFavoriteByTopicAndGroupUser(@Param("topic") Topic topic, @Param("groupUser") GroupUser groupUser);
+
+	@Query("select f from Favorite f join fetch f.topic where f.groupUser = :groupUser")
+	List<Favorite> findAllWithTopicByGroupUser(@Param("groupUser") GroupUser groupUser);
+}

--- a/src/main/java/com/woory/backend/repository/TopicRepository.java
+++ b/src/main/java/com/woory/backend/repository/TopicRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
-import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 public interface TopicRepository extends JpaRepository<Topic, Long>, BatchTopicRepository {
@@ -23,11 +23,15 @@ public interface TopicRepository extends JpaRepository<Topic, Long>, BatchTopicR
 		@Param("date") LocalDate start);
 
 	boolean existsByGroup_GroupIdAndAndIssueDate(long groupId, LocalDate date);
+
 	// hasPrevDay = true 그룹 생성일 보다 조회하는 날짜 - 1일이 뒤임
 	// hasPrevDay = false 그룹 생성일이 조회하는 날짜 -1일이 앞임
 	@Query("select count(t.topicId) > 0 from Topic t where t.group.groupId = :groupId and t.group.groupRegDate < :date")
 	boolean existsByGroupRegDate(@Param("groupId") Long groupId, @Param("date") LocalDate date);
 
-	@Query("select t.topicId from Topic t where t.group.groupId = :groupId and t.issueDate = :date")
-	Optional<Long> findTopicIdByRegDateAndGroupId(@Param("groupId") Long groupId, @Param("date") Date date);
+	@Query("select t from Topic t left join fetch t.content where t.topicId = :topicId")
+	Optional<Topic> findTopicWithContentsByTopicId(@Param("topicId") Long topicId);
+
+	@Query("select t from Topic t left join fetch t.content where t in :topics order by t.issueDate desc")
+	List<Topic> findAllWithContentsByTopics(@Param("topics") List<Topic> topics);
 }

--- a/src/main/java/com/woory/backend/service/ContentService.java
+++ b/src/main/java/com/woory/backend/service/ContentService.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ContentService {
 
 	private static final Logger log = LoggerFactory.getLogger(ContentService.class);
@@ -34,6 +35,7 @@ public class ContentService {
 	private final TopicRepository topicRepository;
 	private final ContentReactionRepository contentReactionRepository;
 	private final AwsService awsService;
+	private final FavoriteRepository favoriteRepository;
 
 	public ContentDto getContentById(Long contentId) {
 		Content content = contentRepository.findByContentId(contentId)
@@ -261,35 +263,6 @@ public class ContentService {
 		contentRepository.save(content);
 	}
 
-	private GroupStatus getGroupStatus(Long userId, Long groupId) {
-		GroupStatus status = groupUserRepository.findByUser_UserIdAndGroup_GroupId(userId, groupId).get().getStatus();
-		return status;
-	}
-
-	private ContentDto convertToDTO(Content content) {
-		ContentDto dto = new ContentDto();
-		dto.setContentId(content.getContentId());
-		dto.setContentText(content.getContentText());
-		dto.setContentImgPath(content.getContentImgPath());
-		dto.setContentRegDate(content.getContentRegDate());
-
-		TopicRequestDto topicDTO = new TopicRequestDto();
-		topicDTO.setTopicId(content.getTopic().getTopicId());
-		topicDTO.setTopicContent(content.getTopic().getTopicContent());
-		topicDTO.setIssueDate(content.getTopic().getIssueDate());
-		topicDTO.setTopicByte(content.getTopic().getTopicByte());
-
-		GroupResponseDto groupDTO = new GroupResponseDto();
-		groupDTO.setGroupId(content.getTopic().getGroup().getGroupId());
-		groupDTO.setGroupName(content.getTopic().getGroup().getGroupName());
-		groupDTO.setPhotoPath(content.getTopic().getGroup().getPhotoPath());
-
-		topicDTO.setGroup(groupDTO);
-		dto.setTopic(topicDTO);
-
-		return dto;
-	}
-
 	private ContentDto convertToDTO1(Content content) {
 		return new ContentDto(
 			content.getContentId(),
@@ -341,5 +314,30 @@ public class ContentService {
 		if (today.isAfter(issueDate)) {
 			throw new CustomException(ErrorCode.CAN_NOT_POST_AFTER_DAY);
 		}
+	}
+
+	public List<FavoriteDto> getFavorites(Long groupId) {
+		Long userId = SecurityUtil.getCurrentUserId();
+		GroupUser groupUser = groupUserRepository.findByUser_UserIdAndGroup_GroupId(userId, groupId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_GROUPS_NOT_FOUND));
+
+		List<Topic> topics = favoriteRepository.findAllWithTopicByGroupUser(groupUser)
+			.stream()
+			.map(Favorite::getTopic)
+			.toList();
+
+		List<Topic> topicWithContents = topicRepository.findAllWithContentsByTopics(topics);
+
+		List<FavoriteDto> result = new ArrayList<>();
+		for (Topic t : topicWithContents) {
+			String contentImg = t.getContent().stream()
+				.map(Content::getContentImgPath)
+				.filter(Objects::nonNull).findFirst()
+				.orElseGet(() -> null);
+
+			result.add(new FavoriteDto(t.getTopicId(), t.getIssueDate(), contentImg, t.getTopicContent()));
+		}
+
+		return result;
 	}
 }


### PR DESCRIPTION
## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

#173 

### 작업중인 브랜치

feat/favorite_select

> 작업 중인 브랜치를 작성해주세요.

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**

- Topic 엔티티의 컨텐츠를 등록날짜 오름차순으로 가져오도록 수정
- 마음함에 필요한 사진과 토픽 내용, 토픽 발행일 그리고 마음 취소에 필요한 토픽ID를 전달할 FavoriteDto추가
- 마음함 조회 메서드 및 엔드포인트 추가
---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
