### PR TITLE
feat : 알림 관련 엔티티 추가

### DIFF
--- a/src/main/java/com/woory/backend/entity/Notification.java
+++ b/src/main/java/com/woory/backend/entity/Notification.java
@@ -1,0 +1,52 @@
+package com.woory.backend.entity;
+
+import java.util.Date;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+
+@Entity
+public class Notification {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long groupId;
+
+	@Temporal(TemporalType.DATE)
+	private Date topicDate;
+
+	private Long topicId;
+
+	private String topicTitle;
+
+	private Long contentUserId;
+
+	private Long contentId;
+
+	private Long commentUserId;
+
+	private Long commentId;
+
+	private Long replyUserId;
+
+	private Long replyId;
+
+	private Long reactionUserId;
+
+	private Long reactionId;
+
+	private Long userId;
+
+	@Enumerated(EnumType.STRING)
+	private NotificationType notificationType;
+
+	@Temporal(TemporalType.DATE)
+	private Date issueDate;
+}

--- a/src/main/java/com/woory/backend/entity/NotificationType.java
+++ b/src/main/java/com/woory/backend/entity/NotificationType.java
@@ -1,0 +1,9 @@
+package com.woory.backend.entity;
+
+public enum NotificationType {
+	TOPIC,
+	CONTENT,
+	REACTION_COMMENT,
+	REACTION_EMOJI,
+	REACTION_REPLY
+}


### PR DESCRIPTION


## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

#185 

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

feat/notification_entity

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**

- 알림 내용을 저장할 Notification 엔티티 추가
- 알림 유형을 나타낼 NotificationType enum 추가

---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

알림 유형을 좀 더 세부적으로 나눠야할 것 같아서 `REACTION_[세부유형]`으로 임시로 해놨습니다. 

기존에 게시글 반응으로 REACTION을 사용해서 `REACTION_EMOJI`로 작성했는데 혹시 괜찮을까요?
