### PR TITLE
feat : 알림함 조회 메서드 추가

### DIFF
--- a/src/main/java/com/woory/backend/dto/NotificationDto.java
+++ b/src/main/java/com/woory/backend/dto/NotificationDto.java
@@ -1,42 +1,47 @@
 package com.woory.backend.dto;
 
 import java.util.Date;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.woory.backend.entity.NotificationType;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface NotificationDto {
+	Long getNotificationId();
+
 	Long getGroupId();
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-	Date getTopicDate();
+	Optional<Date> getTopicDate();
 
-	String getTopicTitle();
+	Optional<Long> getTopicId();
 
-	Long getContentUserId();
+	Optional<String> getTopicTitle();
 
-	Long getContentId();
+	Optional<Long> getContentUserId();
 
-	Long getCommentUserId();
+	Optional<Long> getContentId();
 
-	Long getCommentId();
+	Optional<Long> getCommentUserId();
 
-	Long getReplyUserId();
+	Optional<Long> getCommentId();
 
-	Long getReplyId();
+	Optional<Long> getReplyUserId();
 
-	Long getReactionUserId();
+	Optional<Long> getReplyId();
 
-	Long getReactionId();
+	Optional<Long> getReactionUserId();
 
-	Long getUserId();
+	Optional<Long> getReactionId();
+
+	Optional<Long> getUserId();
 
 	NotificationType getNotificationType();
 
-	String getAuthor();
+	Optional<Date> getIssueDate();
 
-
+	Optional<String> getAuthor();
 
 }

--- a/src/main/java/com/woory/backend/dto/NotificationDto.java
+++ b/src/main/java/com/woory/backend/dto/NotificationDto.java
@@ -1,0 +1,42 @@
+package com.woory.backend.dto;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.woory.backend.entity.NotificationType;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface NotificationDto {
+	Long getGroupId();
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	Date getTopicDate();
+
+	String getTopicTitle();
+
+	Long getContentUserId();
+
+	Long getContentId();
+
+	Long getCommentUserId();
+
+	Long getCommentId();
+
+	Long getReplyUserId();
+
+	Long getReplyId();
+
+	Long getReactionUserId();
+
+	Long getReactionId();
+
+	Long getUserId();
+
+	NotificationType getNotificationType();
+
+	String getAuthor();
+
+
+
+}

--- a/src/main/java/com/woory/backend/entity/Notification.java
+++ b/src/main/java/com/woory/backend/entity/Notification.java
@@ -1,0 +1,122 @@
+package com.woory.backend.entity;
+
+import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Notification {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	private Long groupId;
+
+	@Temporal(TemporalType.DATE)
+	private Date topicDate;
+
+	private Long topicId;
+
+	private String topicTitle;
+
+	private Long contentUserId;
+
+	private Long contentId;
+
+	private Long commentUserId;
+
+	private Long commentId;
+
+	private Long replyUserId;
+
+	private Long replyId;
+
+	private Long reactionUserId;
+
+	private Long reactionId;
+
+	private Long userId;
+
+	@Enumerated(EnumType.STRING)
+	private NotificationType notificationType;
+
+	@Temporal(TemporalType.TIMESTAMP)
+	private Date issueDate;
+
+	// 토픽 생성 시
+	public static Notification fromCreatingTopic(Long groupId, Long topicId, Date topicDate, String topicTitle, Date now) {
+		return Notification.builder()
+			.groupId(groupId)
+			.topicId(topicId)
+			.topicTitle(topicTitle)
+			.topicDate(topicDate)
+			.notificationType(NotificationType.TOPIC)
+			.issueDate(now)
+			.build();
+	}
+
+	// 새 글 생성 시
+	public static Notification fromCreatingContent(Long groupId, Long contentUserId, Long contentId, Date now) {
+		return Notification.builder()
+			.groupId(groupId)
+			.contentUserId(contentUserId)
+			.contentId(contentId)
+			.notificationType(NotificationType.CONTENT)
+			.issueDate(now)
+			.build();
+	}
+
+	public static Notification fromCreatingComment(Long groupId, Long contentId, Long commentUserId, Long commentId, Long userId, Date now) {
+		return Notification.builder()
+			.groupId(groupId)
+			.contentId(contentId) // 원 글로 이동하기 위한 게시글 아이디
+			.commentUserId(commentUserId) // 댓글 작성자
+			.commentId(commentId)
+			.userId(userId) // 원 글 작성자
+			.notificationType(NotificationType.REACTION_COMMENT)
+			.issueDate(new Date())
+			.build();
+	}
+
+	public static Notification fromCreatingReply(Long groupId, Long contentId, Long replyUserId, Long replyId, Long userId, Date now) {
+		return Notification.builder()
+			.groupId(groupId)
+			.contentId(contentId) // 원 글로 이동하기 위한 게시글 아이디
+			.replyUserId(replyUserId) // 답글 작성자
+			.replyId(replyId)
+			.userId(userId) // 원 댓글 작성자
+			.notificationType(NotificationType.REACTION_REPLY)
+			.issueDate(now)
+			.build();
+	}
+
+	public static Notification fromCreatingEmoji(Long groupId, Long contentId, Long reactionUserId, Long reactionId, Long userId, Date now) {
+		return Notification.builder()
+			.groupId(groupId)
+			.contentId(contentId)
+			.reactionUserId(reactionUserId) // 반응 작성자
+			.reactionId(reactionId)
+			.userId(userId) // 원 글 작성자
+			.notificationType(NotificationType.REACTION_EMOJI)
+			.issueDate(now)
+			.build();
+	}
+
+}

--- a/src/main/java/com/woory/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/woory/backend/repository/NotificationRepository.java
@@ -1,0 +1,29 @@
+package com.woory.backend.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.woory.backend.dto.NotificationDto;
+import com.woory.backend.entity.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+	@Query(
+		"select n.groupId, n.topicDate, n.topicTitle, n.contentUserId, n.contentId, n.commentUserId, n.commentId, n.replyUserId, n.replyId, n.reactionUserId, n.reactionId, n.userId, n.notificationType,"
+			+ "case when n.contentUserId is not null then (select u.username from User u where u.userId = n.contentUserId)"
+			+ "when n.commentUserId is not null then (select u.username from User u where u.userId = n.commentUserId) "
+			+ "when n.replyUserId is not null then (select u.username from User u where u.userId = n.replyUserId) "
+			+ "when n.reactionUserId is not null then (select u.username from User u where u.userId = n.reactionUserId) "
+			+ "else null "
+			+ "end as author "
+			+ "from Notification n "
+			+ "where (n.notificationType in (com.woory.backend.entity.NotificationType.CONTENT, com.woory.backend.entity.NotificationType.TOPIC) and n.groupId = :groupId) "
+			+ "or n.userId = :userId "
+			+ "order by n.issueDate desc "
+			+ "limit 10")
+	List<NotificationDto> findAllByUserId(@Param("groupId") Long groupId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/woory/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/woory/backend/repository/NotificationRepository.java
@@ -13,7 +13,7 @@ import com.woory.backend.entity.Notification;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 	@Query(
-		"select n.groupId, n.topicDate, n.topicTitle, n.contentUserId, n.contentId, n.commentUserId, n.commentId, n.replyUserId, n.replyId, n.reactionUserId, n.reactionId, n.userId, n.notificationType,"
+		"select n, "
 			+ "case when n.contentUserId is not null then (select u.username from User u where u.userId = n.contentUserId)"
 			+ "when n.commentUserId is not null then (select u.username from User u where u.userId = n.commentUserId) "
 			+ "when n.replyUserId is not null then (select u.username from User u where u.userId = n.replyUserId) "


### PR DESCRIPTION
## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

#187 새 글, 댓글, 답글, 반응 생성 시 유형에 맞는 알림 저장하는 기능 추가

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

feat/notification_select

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**
- NotificationRepository에 저장된 알림을 불러오는 메서드 추가
- 새글이나 토픽 알림일 경우 그룹에 속한 모두에게, 반응 알림일 경우 댓글 또는 글 작성자로 조회
- 이를 받아올 Dto 인터페이스 추가
---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
