### PR TITLE
쿼리가 테이블명에 맞도록 수정

### DIFF
--- a/src/main/java/com/woory/backend/repository/NotificationRepository.java
+++ b/src/main/java/com/woory/backend/repository/NotificationRepository.java
@@ -14,12 +14,12 @@ import com.woory.backend.entity.Notification;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 	@Query(
 		value = "select *, "
-			+ "case when content_user_id is not null then (select u.nickname from User u where u.user_id = n.content_user_id)"
-			+ "when comment_user_id is not null then (select u.nickname from User u where u.user_id = n.comment_user_id) "
-			+ "when reply_user_id is not null then (select u.nickname from User u where u.user_id = n.reply_user_id) "
-			+ "when reaction_user_id is not null then (select u.nickname from User u where u.user_id = n.reaction_user_id) "
+			+ "case when content_user_id is not null then (select u.nickname from user u where u.user_id = n.content_user_id)"
+			+ "when comment_user_id is not null then (select u.nickname from user u where u.user_id = n.comment_user_id) "
+			+ "when reply_user_id is not null then (select u.nickname from user u where u.user_id = n.reply_user_id) "
+			+ "when reaction_user_id is not null then (select u.nickname from user u where u.user_id = n.reaction_user_id) "
 			+ "end as author "
-			+ "from Notification n "
+			+ "from notification n "
 			+ "where (notification_type in ('CONTENT', 'TOPIC') and group_id = :groupId) "
 			+ "or n.user_id = :userId "
 			+ "order by issue_date desc, notification_id desc "


### PR DESCRIPTION
- JPQL의 엔티티명 Notification, User가 아닌 테이블명 notificaion, user로 수정

## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

fix/notification_search

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**
- JPQL의 엔티티명 Notification, User가 아닌 테이블명 notificaion, user로 수정

---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
