### PR TITLE
Oauth2 인증 실패시 프론트엔드로 리디렉션하도록 수정

### DIFF
--- a/src/main/java/com/woory/backend/config/SecurityConfig.java
+++ b/src/main/java/com/woory/backend/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
 				.userInfoEndpoint(userInfoEndpointConfig ->
 					userInfoEndpointConfig.userService(oAuth2UserService))
 				.successHandler(successHandler) // 로그인 성공 시에 응답에 토큰 넣어줌
-			) //서버전달체계만들어줌
+				.failureUrl("https://woory.vercel.app")
+			)
 			.exceptionHandling(handler ->
 				// 인증 없이 이용하려면 401
 				handler.defaultAuthenticationEntryPointFor(


### PR DESCRIPTION
## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

refactor/redirect_authentication_fails

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**
- 기존 oauth2 인증 실패 시 백엔드 로그인 페이지가 노출되는 문제를 해결
---      

**스크린샷(선택)**

*문제가 되었던 화면*
![image](https://github.com/user-attachments/assets/eacb24f8-56fe-4544-bb99-8daa6f0ae2d8)

*해결된 이후 화면*
![Aug-26-2024 15-26-34](https://github.com/user-attachments/assets/31b9ae93-68aa-4ada-8995-6794fe48e46a)


---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
