### PR TITLE
fix : api 경로에 대해서만 https로 리다이렉트시키도록 수정

### DIFF
--- a/src/main/java/com/woory/backend/config/SendHttpRedirectConfig.java
+++ b/src/main/java/com/woory/backend/config/SendHttpRedirectConfig.java
@@ -19,7 +19,7 @@ public class SendHttpRedirectConfig {
 				SecurityConstraint securityConstraint = new SecurityConstraint();
 				securityConstraint.setUserConstraint("CONFIDENTIAL");
 				SecurityCollection collection = new SecurityCollection();
-				collection.addPattern("/*");
+				collection.addPattern("/v*/**");
 				securityConstraint.addCollection(collection);
 				context.addConstraint(securityConstraint);
 			}
@@ -29,7 +29,7 @@ public class SendHttpRedirectConfig {
 	}
 
 	private Connector createStandardConnector() {
-		Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+		Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
 		connector.setScheme("http");
 		connector.setSecure(false);
 		connector.setPort(80);


### PR DESCRIPTION
- ssl webroot모드 갱신 과정에서 https로 리다이렉트 시 인증 실패하는 문제가 있어 정적 경로에 대해서는 리다이렉트 시키지 않도록 수정

## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

#211 #214 

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

refactor/redirectHttpToHttps

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**
api 경로(/v*/**)에 대해서만 http -> https 리다이렉트하도록 수정
- http - 01 챌린지에서 http -> https로 리다이렉트 되면 401과 함께 인증 실패가 발생함.

---      

**스크린샷(선택)**

---    
    
### 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


ex) 메서드 이름을 더 명확하게 나타내고 싶은데 혹시 좋은 명칭이 있을까요?
