### PR TITLE
fix : 이미지 링크가 확장자 처리를 제대로 하지 못하던 문제 수정

### DIFF
--- a/src/main/java/com/woory/backend/utils/PhotoUtils.java
+++ b/src/main/java/com/woory/backend/utils/PhotoUtils.java
@@ -54,11 +54,7 @@ public class PhotoUtils {
 
 	private static String getFileExtensionFromURL(String imagePath) {
 		String[] split = imagePath.split("\\.");
-		if (split.length < 3) {
-			throw new CustomException(ErrorCode.FILE_IS_NOT_IMAGE);
-		}
-		return "image/" + split[3];
-
+		return "image/" + split[split.length - 1];
 	}
 
 	public static MultipartFile base64ToMultipartFile(String base64File) {


### PR DESCRIPTION
## PULL REQUEST

### 관련 이슈

> 관련 이슈를 입력해주세요.

#224 

### 작업중인 브랜치

> 작업 중인 브랜치를 작성해주세요.

fix/saving_image

### 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능).

**주요 변경사항**
- 기존의 경우 "."을 기준으로 나눠진 url의 가장 마지막으로 3번쨰라고 판단하여 3번쨰 원소를 취하도록 했음.
- 그러나 url에 따라 유동적으로 변할 수 있어 배열의 가장 마지막 원소를 확장자로 취하도록 수정

